### PR TITLE
[fix] the calculated crash duration time is negative

### DIFF
--- a/scripts/check_crash.py
+++ b/scripts/check_crash.py
@@ -697,7 +697,7 @@ def main(args: Namespace):
                                     crash_triggering_datetime_obj = datetime.datetime.strptime(matched_datetime_str,
                                                                                                '%Y-%m-%d-%H:%M:%S')
                                 else:
-                                    matched_datetime_str = "2020-" + time_label.split('.')[0]
+                                    matched_datetime_str = "{}-{}".format(start_testing_datetime_obj.year, time_label.split('.')[0])
                                     crash_triggering_datetime_obj = datetime.datetime.strptime(matched_datetime_str,
                                                                                                '%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
we found that when the crash is triggered after 2020, the calculated crash duration time is negative. In order to fix this issue, we use the year of the test start time as the year of the crash time instead of using the fixed prefix "2020".